### PR TITLE
fix(hybrid): unblock HybridModel + A2A overlap and align MoE aux-loss logging

### DIFF
--- a/megatron/core/models/hybrid/fine_grained_callables.py
+++ b/megatron/core/models/hybrid/fine_grained_callables.py
@@ -45,6 +45,18 @@ class _SharedExpertBackwardDWWrapper:
         self.layer = None
         self.shared_expert_dw_callable = None
 
+    def parameters(self):
+        """Expose shared-expert params so post_wgrad_grad_acc_hook discovery works.
+
+        The schedule node's backward_dw iterates module.parameters() looking for
+        post_wgrad_grad_acc_hook on each param. _SharedExpertBackwardDWWrapper is
+        a plain class (not nn.Module), so we forward to layer.mlp.shared_experts.
+        Returns an empty iterator after backward_dw has cleared the layer ref.
+        """
+        if self.layer is None or self.layer.mlp.shared_experts is None:
+            return iter([])
+        return self.layer.mlp.shared_experts.parameters()
+
 
 class HybridStackNode(TransformerLayerNode):
     """Schedule node for HybridStack-built fine-grained callables.

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -194,6 +194,7 @@ class HybridStack(MegatronModule):
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
+                        is_mtp_layer=is_mtp_layer,
                     )
                 elif layer_type == LayerSymbols.GDN:
                     layer = build_module(

--- a/megatron/core/models/hybrid/model_chunk_schedule_plan.py
+++ b/megatron/core/models/hybrid/model_chunk_schedule_plan.py
@@ -128,7 +128,7 @@ class HybridStackModelChunkSchedulePlan(TransformerModelChunkSchedulePlan):
             "EP A2A overlap with grouped HybridStack patterns (e.g. '[*E]') does not "
             "support cuda graphs yet. Set cuda_graph_impl='none' or use an ungrouped pattern."
         )
-        super().init(model, *args, **kwargs)
+        super().__init__(model, *args, **kwargs)
 
     def _extra_args_for_layer(self, module, layer_idx, num_layers):
         extra_args = super()._extra_args_for_layer(module, layer_idx, num_layers)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -459,16 +459,21 @@ class TopKRouter(Router):
         ):
             aux_loss = aux_loss / self.config.mtp_num_layers
 
-        # TODO (zijiey): fix the per_layer_logging for MTP, currently it will incorrectly
-        # add the aux loss logging value to other layer's since it is difficult to get the
-        # correct layer_number for MTP. It does not affect the correctness of the calculation
-        # results and the reduced load_balancing_loss logging value.
+        # The tracker has one slot per main decoder layer and one per MTP depth, so its
+        # size is (num_layers + mtp_num_layers). For MTP routers, the slot index must be
+        # in [num_layers + 1, num_layers + mtp_num_layers]. When the MTP block wraps a
+        # plain TransformerLayer, ``self.layer_number`` already equals the MTP depth
+        # (1..mtp_num_layers). When it wraps a HybridStack (e.g. ``*E`` for one depth),
+        # ``self.layer_number`` is the position within the inner HybridStack and can
+        # exceed mtp_num_layers, which would index past the tracker; collapse it to a
+        # valid MTP-depth slot via modulo so the aux loss lands at the right depth.
         num_layers = self.config.num_layers
         if self.config.mtp_num_layers is not None:
             num_layers += self.config.mtp_num_layers
 
         if self.is_mtp_layer:
-            layer_number = self.layer_number + self.config.num_layers
+            mtp_depth = ((self.layer_number - 1) % self.config.mtp_num_layers) + 1
+            layer_number = mtp_depth + self.config.num_layers
         else:
             layer_number = self.layer_number
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2291,13 +2291,24 @@ def training_log(
             track_names.append("z_loss")
 
         if is_hybrid_model(args):
-            from operator import itemgetter
-
-            from megatron.core.ssm.mamba_hybrid_layer_allocation import (
+            from megatron.core.models.hybrid.hybrid_layer_allocation import (
                 Symbols,
-                get_hybrid_layer_counts,
+                flatten_layer_type_list,
+                parse_hybrid_pattern,
+                validate_segment_layers,
             )
-            layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
+
+            # Pass only MAIN-pattern MoE count (excluding MTP) to track_moe_metrics:
+            # the function adds mtp_num_layers internally to derive the divisor.
+            # ``get_hybrid_layer_counts`` already aggregates MTP, which would
+            # double-count and inflate the denominator.
+            parsed = parse_hybrid_pattern(args.hybrid_layer_pattern)
+            layers = 0
+            if parsed.main_pattern:
+                for segment in parsed.main_pattern.split(Symbols.PIPE):
+                    for char in flatten_layer_type_list(validate_segment_layers(segment)):
+                        if char == Symbols.MOE:
+                            layers += 1
         else:
             layers = args.num_layers
 


### PR DESCRIPTION
## Summary

Three commits, all targeting `HybridModel + EP A2A overlap`. The first
two unblock the path (it crashes without them); the third makes the
`seq_load_balancing_loss` metric match the equivalent GPT model.

### 1. `super().__init__` typo (crash on every Hybrid+A2A=1 run)

`HybridStackModelChunkSchedulePlan.__init__` called `super().init(...)`
instead of `super().__init__(...)`. Raises `AttributeError: 'super' object
has no attribute 'init'` on first `build_schedule_plan`. Introduced in
`5b9e9bf96` ("revert ckpt final_layernorm for hybrid stack & assertion on
cuda graph").

### 2. Missing `parameters()` on `_SharedExpertBackwardDWWrapper`

After fixing (1), iter-1 backward crashes:
```
File "megatron/core/models/common/utils.py:337", in backward_dw
    for param in module.parameters():
AttributeError: '_SharedExpertBackwardDWWrapper' object has no attribute 'parameters'
```
The schedule node iterates `bwd_dw_callable.parameters()` to collect
`post_wgrad_grad_acc_hook` references. `_SharedExpertBackwardDWWrapper`
is a plain class (not `nn.Module`). Forward to
`layer.mlp.shared_experts.parameters()`; return an empty iterator after
`backward_dw` cleared the layer ref.

### 3. `seq_load_balancing_loss` mismatch between GPT and Hybrid

After (1)+(2), `HybridModel + MTP + A2A=1` runs cleanly and `lm loss`
matches the equivalent GPT model bitwise — but the displayed
`seq_load_balancing_loss` for hybrid was systematically low by ~10%
(0.969654 vs 1.077394 in the DeepSeek-V3-Lite-deter MoE test). Doesn't
affect training (aux loss is attached to autograd separately), but the
metric is misleading.

Three small fixes, none change training math:

- **`megatron/training/training.py`** (root cause of the visible gap):
  for hybrid models, `get_hybrid_layer_counts` already aggregates MTP
  layers into its return, then `track_moe_metrics` adds `mtp_num_layers`
  again — double-counting and inflating the averaging denominator (9 → 10
  for the 8-layer + 1-MTP test, giving the 9/10 ≈ 0.9 ratio). Pass only
  the main-pattern MoE count so the denominator matches GPT's
  `args.num_layers + mtp_num_layers` convention.

- **`megatron/core/transformer/moe/router.py`**: when an MTP block wraps a
  HybridStack (e.g. `*E` for one depth), the inner router's
  `self.layer_number` is the position inside the HybridStack (`2` for
  `*E`), not the MTP depth (`1`). Map back to a valid MTP-depth slot via
  modulo before indexing the aux-loss tracker, addressing the existing
  TODO in this block.

- **`megatron/core/models/hybrid/hybrid_block.py`**: the MOE build branch
  in `HybridStack` was the only one not propagating `is_mtp_layer` to
  inner modules (ATTENTION/DS_ATTENTION already do). Without it, the
  router inside an MTP-wrapped HybridStack's `E` layer sees
  `is_mtp_layer=False` and skips MTP-aware paths (including the slot
  mapping in fix #3 above and the repeated-MTP scale-down).

## Test plan

Reproduced on aws-dfw (2× 4-GPU arm GB300) and cmh from @pingtianl's
recipe:

```
NUM_LAYERS=8  A2A_OVERLAP={0,1} MODEL=DeepSeek-V3-Lite-deter \
  bash interactive_benchmarking.sh --mtp-num-layers 1 \
  --pipeline-model-parallel-layout "Et|(t|)*6tmL"

NUM_LAYERS=16 A2A_OVERLAP={0,1} MODEL=DeepSeek-V3-Lite-deter-Hybrid \
  bash interactive_benchmarking.sh --mtp-num-layers 1 \
  --hybrid-layer-pattern '*E|*E|*E|*E|*E|*E|*E|*E/*E'
```

- Before commits 1+2: Hybrid+A2A=1 crashes at `build_schedule_plan`; after
  fix 1, crashes at iter-1 backward. After both, 4 configs run cleanly.
- After commit 3: `seq_load_balancing_loss` aligns to 1.077394 across all
  four configurations, matching `lm loss`'s existing bitwise alignment
  (80/80 iterations).

Comparison runs in one wandb project:
https://wandb.ai/nvidia/Pingtian-DeepSeek-V3-Lite-deter-MTP-Comparison

## Followup (not in this PR)

The cuda-graph assertion message in
`HybridStackModelChunkSchedulePlan.__init__` says "EP A2A overlap with
**grouped** HybridStack patterns (e.g. '[*E]')" — but the assertion fires
for *all* hybrid configs including ungrouped patterns. Either narrow the
guard to `is_grouped(pattern)` or rewrite the message. Filed separately
so this PR stays minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)